### PR TITLE
Add default behavior for osd_to_dict

### DIFF
--- a/src/pytesseract.py
+++ b/src/pytesseract.py
@@ -199,9 +199,26 @@ def file_to_dict(tsv, cell_delimiter, str_col_idx):
     return result
 
 
+def is_valid(val, _type):
+    if _type is int:
+        return val.isdigit()
+
+    if _type is float:
+        try:
+            float(val)
+            return True
+        except ValueError:
+            return False
+
+    return True
+
+
 def osd_to_dict(osd):
-    lines = (line.split(': ') for line in osd.split('\n'))
-    return {OSD_KEYS[k][0]: OSD_KEYS[k][1](v) for k, v in lines}
+    return {
+        OSD_KEYS[kv[0]][0]: OSD_KEYS[kv[0]][1](kv[1]) for kv in (
+            line.split(': ') for line in osd.split('\n')
+        ) if len(kv) == 2 and is_valid(kv[1], OSD_KEYS[kv[0]][1])
+    }
 
 
 def image_to_string(image,


### PR DESCRIPTION
Prevent osd_to_dict from throwing all sorts of ValueError exceptions, if the tesseract executable returns malformed/invalid result.
The current commit minimizes that behavior. Unfortunately the osd.split() usage is still present,
which counters the utilization of generator. TODO: replace that statement with lazy evaluated alternative.